### PR TITLE
bump text dependency

### DIFF
--- a/snap-web-routes.cabal
+++ b/snap-web-routes.cabal
@@ -66,7 +66,7 @@ library
     mtl                       >= 2       && < 3,
     snap-core                 >= 0.9     && < 1.1,
     snap                      >= 0.13    && < 1.1,
-    text                      >= 0.11    && < 1.2,
+    text                      >= 0.11    && < 1.3,
     web-routes                >= 0.27    && < 0.28,
     xmlhtml                   >= 0.1
 


### PR DESCRIPTION
Just a tiny change so this builds with modern-day hackage. (Incidentally only web-routes HEAD builds with snap-0.14.\* because of nasty dependency issues)
