### PR TITLE
Bump heist dependency version so it works with most recent snaplet-pe…

### DIFF
--- a/snap-web-routes.cabal
+++ b/snap-web-routes.cabal
@@ -62,7 +62,7 @@ library
   build-depends:
     base                      >= 4.4     && < 5,
     bytestring                >= 0.9.1   && < 0.11,
-    heist                     >= 0.13    && < 1.1,
+    heist                     >= 0.13    && < 1.20,
     mtl                       >= 2       && < 3,
     snap-core                 >= 0.9     && < 1.1,
     snap                      >= 0.13    && < 1.1,


### PR DESCRIPTION
…rsistent package
